### PR TITLE
Search with unit test

### DIFF
--- a/project/app/src/main/java/com/example/cmput301w21t25/Experiment.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/Experiment.java
@@ -29,6 +29,12 @@ public class Experiment { //make abstract
 
     public ArrayList<String> getKeywords() { return keywords; }
 
+    public void setName(String name) { this.name = name; }
+
+    public void setType(String type) { this.type = type; }
+
+    public void setKeywords(ArrayList<String> keywords) { this.keywords = keywords; }
+
     public void setTrials(ArrayList<Trial> trials) {
         this.trials = trials;
     }

--- a/project/app/src/main/java/com/example/cmput301w21t25/SearchManager.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/SearchManager.java
@@ -13,6 +13,7 @@ public class SearchManager {
         StringTokenizer splitKeywords = new StringTokenizer(keywords, ",");
 
         while (splitKeywords.hasMoreTokens()) {
+            //Log.d("TEST_PARSE", splitKeywords.);
             String keyword = (String) splitKeywords.nextToken();
 
             if (keyword.trim().length() > 0) {
@@ -20,13 +21,37 @@ public class SearchManager {
             }
         }
 
-        //For testing purposes
+        /*//For testing purposes
         for (String i: keywordList) {
             Log.d("TEST_PARSE", i);
         }
 
         Log.d("CAT", (Integer.toString(keywordList.get(0).length())));
-        //End of testing
+        //End of testing*/
+
+        return keywordList;
+    }
+
+    public ArrayList<String> parseTitle(String keywords) {
+
+        ArrayList<String> keywordList = new ArrayList<String>();
+        StringTokenizer splitKeywords = new StringTokenizer(keywords, " ");
+
+        while (splitKeywords.hasMoreTokens()) {
+            String keyword = (String) splitKeywords.nextToken();
+
+            if (keyword.trim().length() > 0) {
+                keywordList.add(keyword.trim().toLowerCase());
+            }
+        }
+
+        /*//For testing purposes
+        for (String i: keywordList) {
+            Log.d("TEST_PARSE", i);
+        }
+
+        Log.d("CAT", (Integer.toString(keywordList.get(0).length())));
+        //End of testing*/
 
         return keywordList;
     }
@@ -67,7 +92,7 @@ public class SearchManager {
 
         //Compares keywords with experiment names
         for (int i = 0; i < allExperiments.size(); i++) {
-            ArrayList<String> experimentName = this.parseKeywords(allExperiments.get(i).getName());
+            ArrayList<String> experimentName = this.parseTitle(allExperiments.get(i).getName());
             for (String titleWord: experimentName) {
                 for (String keyword: keywordList) {
                     if (titleWord.equals(keyword)) {
@@ -107,22 +132,28 @@ public class SearchManager {
         //the experiment will already be displayed in search so multiple matches are not of interest)
         ArrayList<Experiment> typeKeywordExperiments = this.searchType(keywordList, allExperiments);
         for (int i = 0; i < typeKeywordExperiments.size(); i++) {
-            keywordExperiments.add(typeKeywordExperiments.get(i));
-            allExperiments.remove(typeKeywordExperiments.get(i));
+            if (!keywordExperiments.contains(typeKeywordExperiments.get(i))) {
+                keywordExperiments.add(typeKeywordExperiments.get(i));
+                //allExperiments.remove(typeKeywordExperiments.get(i));
+            }
         }
 
         //The same as with type, but with experiment name matches
         ArrayList<Experiment> experimentNameKeywordExperiments = this.searchExperimentName(keywordList, allExperiments);
         for (int i = 0; i < experimentNameKeywordExperiments.size(); i++) {
-            keywordExperiments.add(experimentNameKeywordExperiments.get(i));
-            allExperiments.remove(experimentNameKeywordExperiments.get(i));
+            if (!keywordExperiments.contains(experimentNameKeywordExperiments.get(i))) {
+                keywordExperiments.add(experimentNameKeywordExperiments.get(i));
+                //allExperiments.remove(experimentNameKeywordExperiments.get(i));
+            }
         }
 
         //The same as with type, but with experiment keyword matches
         ArrayList<Experiment> experimentKeywordsKeywordExperiments = this.searchExperimentKeywords(keywordList, allExperiments);
         for (int i = 0; i < experimentKeywordsKeywordExperiments.size(); i++) {
-            keywordExperiments.add(experimentKeywordsKeywordExperiments.get(i));
-            allExperiments.remove(experimentKeywordsKeywordExperiments.get(i));
+            if (!keywordExperiments.contains(experimentKeywordsKeywordExperiments.get(i))) {
+                keywordExperiments.add(experimentKeywordsKeywordExperiments.get(i));
+                //allExperiments.remove(experimentKeywordsKeywordExperiments.get(i));
+            }
         }
 
         return keywordExperiments;

--- a/project/app/src/main/java/com/example/cmput301w21t25/TempRightActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/TempRightActivity.java
@@ -18,7 +18,7 @@ public class TempRightActivity extends AppCompatActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_temp_right);
 
-        searchManager.parseKeywords(" cat, dog cat,  ,, BUTTS");
+        searchManager.parseKeywords("binomial, ,   ");
     }
 
     @Override

--- a/project/app/src/test/java/com/example/cmput301w21t25/SearchTest.java
+++ b/project/app/src/test/java/com/example/cmput301w21t25/SearchTest.java
@@ -1,0 +1,84 @@
+package com.example.cmput301w21t25;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+
+public class SearchTest {
+
+    private Experiment mockExperiment() {
+        Experiment mockExperiment = new Experiment();
+
+        return mockExperiment;
+    }
+
+    private SearchManager mockSearchManager() {
+        SearchManager mockSearchManager = new SearchManager();
+
+        return mockSearchManager;
+    }
+
+    @Test
+    void testSearch() {
+        ArrayList<Experiment> experiments = new ArrayList<Experiment>();
+        SearchManager searchManager = mockSearchManager();
+        String userInput1 = "DUNCAN, measurement";
+        String userInput2 = "  stupid, butt";
+        String userInput3 = "true";
+        String userInput4 = "nope, not, match, with, anything";
+
+        //The test assumes that keywords are properly parsed and made all lower case
+        //at the time of user input
+        //The test also assumes experiment name has been validated-- no special characters,
+        //only spaces
+        ArrayList<String> keywords1 = new ArrayList<String>();
+        keywords1.add("butt");
+        keywords1.add("stupid");
+        keywords1.add("funny");
+
+        ArrayList<String> keywords2 = new ArrayList<String>();
+        keywords2.add("cats");
+        keywords2.add("dogs");
+
+        Experiment experiment1 = mockExperiment();
+        experiment1.setName("Duncan is a Dingus");
+        experiment1.setKeywords(keywords1);
+        experiment1.setType("binomial");
+
+        Experiment experiment2 = mockExperiment();
+        experiment2.setName("Yup that's True");
+        experiment2.setKeywords(keywords2);
+        experiment2.setType("measurement");
+
+        experiments.add(experiment1);
+        experiments.add(experiment2);
+        //Make copies of array because APPARENTLY JAVA IS PASS BY REFERENCE MY GOD
+        ArrayList<Experiment> newExperiments = new ArrayList<Experiment>(experiments);
+        ArrayList<Experiment> newExperiments2 = new ArrayList<Experiment>(experiments);
+        ArrayList<Experiment> newExperiments3 = new ArrayList<Experiment>(experiments);
+
+        //Test both have key word match (name and type)
+        ArrayList<Experiment> keywordExperiments = searchManager.searchExperiments(userInput1, experiments);
+        assertTrue(keywordExperiments.contains(experiment1));
+        assertTrue(keywordExperiments.contains(experiment2));
+        assertEquals(2, keywordExperiments.size());
+
+        //Test 1st has match (keyword) with repeat
+        keywordExperiments = searchManager.searchExperiments(userInput2, newExperiments);
+        assertTrue(keywordExperiments.contains(experiment1));
+        assertEquals(1, keywordExperiments.size());
+
+        //Test 2nd has match (name)
+        keywordExperiments = searchManager.searchExperiments(userInput3, newExperiments2);
+        assertTrue(keywordExperiments.contains(experiment2));
+        assertEquals(1, keywordExperiments.size());
+
+        //Test no matches
+        keywordExperiments = searchManager.searchExperiments(userInput4, newExperiments3);
+        assertEquals(0, keywordExperiments.size());
+
+
+
+    }
+}


### PR DESCRIPTION
WILD STUFF IS HAPPENING. I have learned:

-Java is seemingly pass by reference. This maybe complicates search. Originally I would delete an experiment from a list of all experiments when it found a keyword match (because I thought that list was a copy). Then, with testing I found my list was empty after the first pass, so it seems it was a reference to the real deal. Now instead of deleting, before I add to the match list, I check whether it's already in there. It could result in a lot of extra comparisons which sucks, but I'm not sure how else to do it at present. I figured having to copy all experiments from the database into an array every single time someone searched (instead of just updating it when a new experiment was published) would be as strenuous, but we can talk it out. 