### PR TITLE
Replaced switch cases to have consistent names for nonnegative count

### DIFF
--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_main/HomeOwnedActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_main/HomeOwnedActivity.java
@@ -168,7 +168,7 @@ public class HomeOwnedActivity extends AppCompatActivity {
                                             ownedExperiments.add(countExp);
                                             experimentAdapter.notifyDataSetChanged();
                                             break;
-                                        case "non-neg-count":
+                                        case "nonnegative count":
                                             NonNegCountExperiment nnCountExp = document.toObject(NonNegCountExperiment.class);
                                             nnCountExp.setFb_id(document.getId());
                                             ownedExperiments.add(nnCountExp);

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_main/HomeSubbedActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_main/HomeSubbedActivity.java
@@ -173,7 +173,7 @@ public class HomeSubbedActivity extends AppCompatActivity {
                                             subbedExperiments.add(countExp);
                                             experimentAdapter.notifyDataSetChanged();
                                             break;
-                                        case "non-neg-count":
+                                        case "nonnegative count":
                                             NonNegCountExperiment nnCountExp = document.toObject(NonNegCountExperiment.class);
                                             nnCountExp.setFb_id(document.getId());
                                             subscriptionList.add(nnCountExp);

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_main/SearchActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_main/SearchActivity.java
@@ -115,7 +115,7 @@ public class SearchActivity extends AppCompatActivity {
                                                     experimentList.add(countExp);
                                                     experimentArrayAdapter.notifyDataSetChanged();
                                                     break;
-                                                case "non-neg-count":
+                                                case "nonnegative count":
                                                     NonNegCountExperiment nnCountExp = document.toObject(NonNegCountExperiment.class);
                                                     nnCountExp.setFb_id(document.getId());
                                                     experimentList.add(nnCountExp);


### PR DESCRIPTION
I had changed a variable without changing Yalmaz's switch cases-- fixed it.