### PR TITLE
Converted trial upload to dialog

### DIFF
--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/AddTrialActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/AddTrialActivity.java
@@ -12,6 +12,7 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.example.cmput301w21t25.R;
 import com.example.cmput301w21t25.activities_user.MyUserProfileActivity;
 import com.example.cmput301w21t25.custom.CustomListTrial;
+import com.example.cmput301w21t25.custom.UploadTrialDialogFragment;
 import com.example.cmput301w21t25.experiments.Experiment;
 import com.example.cmput301w21t25.managers.TrialManager;
 import com.example.cmput301w21t25.trials.Trial;
@@ -22,7 +23,7 @@ import java.util.ArrayList;
 /**
  * this activity is used to add new trials and view unpublished trials
  */
-public class AddTrialActivity extends AppCompatActivity {
+public class AddTrialActivity extends AppCompatActivity implements UploadTrialDialogFragment.OnFragmentInteractionListener {
 
     ListView trialListView;
     ArrayAdapter<Trial> trialArrayAdapter;
@@ -57,7 +58,7 @@ public class AddTrialActivity extends AppCompatActivity {
         trialListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                publishTrial(position);
+                new UploadTrialDialogFragment(position).show(getSupportFragmentManager(), "UPLOAD_TRIAL");
             }
         });
 
@@ -126,11 +127,11 @@ public class AddTrialActivity extends AppCompatActivity {
      * @param position
      * The index of the trial you want to publish in the list
      */
-    public void publishTrial(int position) {
-        Trial temp = trialList.remove(position);
+    @Override
+    public void publishTrial(Integer position) {
+        Trial temp = trialList.get(position);
         temp.setPublished(true);
         trialManager.FB_UpdatePublished(true, temp.getTrialId());
         trialArrayAdapter.notifyDataSetChanged();
     }
-
 }

--- a/project/app/src/main/java/com/example/cmput301w21t25/custom/UploadTrialDialogFragment.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/custom/UploadTrialDialogFragment.java
@@ -1,0 +1,62 @@
+package com.example.cmput301w21t25.custom;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import com.example.cmput301w21t25.R;
+
+public class UploadTrialDialogFragment extends DialogFragment {
+
+    public interface OnFragmentInteractionListener {
+        void publishTrial(Integer position);
+    }
+
+    private OnFragmentInteractionListener listener;
+    private Integer position;
+
+    public UploadTrialDialogFragment(Integer position) {
+        this.position = position;
+    }
+
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof OnFragmentInteractionListener){
+            listener = (OnFragmentInteractionListener) context;
+        } else {
+            throw new RuntimeException(context.toString()
+                    + " must implement OnFragmentInteractionListener");
+        }
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        View view = LayoutInflater.from(getActivity()).inflate(R.layout.upload_trial_fragment, null);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+        return builder
+                .setView(view)
+                .setTitle("              Upload Trial?")
+                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int i) {
+                    }
+                })
+                .setPositiveButton("Upload", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        listener.publishTrial(position);
+                    }}).create();
+    }
+}

--- a/project/app/src/main/res/layout/upload_trial_fragment.xml
+++ b/project/app/src/main/res/layout/upload_trial_fragment.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="100dp" >
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="This Action Cannot Be Undone."
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
If people can give this a quick test and then merge I'd appreciate it! 

I just updated it so that instead of a click uploading a trial immediately, it brings up a dialog. I only testing on count trials, and while it should be the same for all, it would be good for everyone to do a few trials for a few different experiments just to test!