### PR TITLE
Hiding trials eden

### DIFF
--- a/project/app/src/main/AndroidManifest.xml
+++ b/project/app/src/main/AndroidManifest.xml
@@ -61,6 +61,8 @@
         <activity android:name=".activities_trials.ViewTrialActivity" />
         <activity android:name=".activities_experiments.ExperimentDataActivity" />
         <activity android:name=".activities_trials.AddTrialActivity" />
+        <activity android:name=".activities_trials.HideTrialActivity"
+            android:label="Manage Visible Trials"/>
         <activity android:name=".activities_trials.ConductCountTrialActivity" />
         <activity android:name=".activities_trials.ConductMeasurementTrialActivity" />
         <activity android:name=".activities_trials.ConductBinomialTrialActivity" />

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_experiments/CreateExperimentActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_experiments/CreateExperimentActivity.java
@@ -63,9 +63,6 @@ public class CreateExperimentActivity extends AppCompatActivity {
         //Initialize experiment manager
         experimentManager = new ExperimentManager();
 
-        //This is temp I don't know what to do for location
-        //String testRegion = "EMPTY STRING";
-
         experimentName = findViewById(R.id.editTextExpName);
         experimentDescription = findViewById(R.id.editTextEnterDescription);
         experimentTags = findViewById(R.id.editTextKeywords);

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_experiments/ViewCreatedExperimentActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_experiments/ViewCreatedExperimentActivity.java
@@ -14,6 +14,7 @@ import com.example.cmput301w21t25.R;
 import com.example.cmput301w21t25.activities_forum.ForumActivity;
 import com.example.cmput301w21t25.activities_main.SearchExperimentsActivity;
 import com.example.cmput301w21t25.activities_trials.AddTrialActivity;
+import com.example.cmput301w21t25.activities_trials.HideTrialActivity;
 import com.example.cmput301w21t25.activities_user.MyUserProfileActivity;
 import com.example.cmput301w21t25.activities_user.OtherUserProfileActivity;
 import com.example.cmput301w21t25.experiments.Experiment;
@@ -52,6 +53,7 @@ public class ViewCreatedExperimentActivity extends AppCompatActivity {
         final Button unpublishButton = findViewById(R.id.unpublish_button);
         final Button commentsButton = findViewById(R.id.comments_button);
         final Button dataButton = findViewById(R.id.view_data_button);
+        final Button hideTrialButton = findViewById(R.id.hideTrialsButton);
 
         userID = getIntent().getStringExtra("USER_ID");
         exp = unpackExperiment();
@@ -134,6 +136,16 @@ public class ViewCreatedExperimentActivity extends AppCompatActivity {
                 switchScreens.putExtra("USER_ID", userID);
                 switchScreens.putExtra("EXP", exp);
                 startActivity(switchScreens);
+            }
+        });
+
+        hideTrialButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Intent hideTrials = new Intent(ViewCreatedExperimentActivity.this, HideTrialActivity.class);
+                hideTrials.putExtra("USER_ID", userID);
+                hideTrials.putExtra("EXPERIMENT", exp);
+                startActivity(hideTrials);
             }
         });
 

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_forum/ForumActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_forum/ForumActivity.java
@@ -74,7 +74,7 @@ public class ForumActivity extends AppCompatActivity {
         forumListView = findViewById(R.id.forum_list);
         askQuestionButton = findViewById(R.id.add_comment_button);
 
-        commentArrayAdapter = new CustomListComment(this, comments, forumExperiment, userID);
+        commentArrayAdapter = new CustomListComment(this, comments, forumExperiment);
         forumListView.setAdapter(commentArrayAdapter);
 
         //Database call commented out for proof of sorting

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/AddTrialActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/AddTrialActivity.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 /**
  * this activity is used to add new trials and view unpublished trials
  */
-public class AddTrialActivity extends AppCompatActivity implements UploadTrialDialogFragment.OnFragmentInteractionListener {
+public class AddTrialActivity extends AppCompatActivity implements UploadTrialDialogFragment.OnFragmentInteractionListenerUpload {
 
     ListView trialListView;
     ArrayAdapter<Trial> trialArrayAdapter;

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/HideTrialActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/HideTrialActivity.java
@@ -16,6 +16,8 @@ import com.example.cmput301w21t25.activities_main.CreatedExperimentsActivity;
 import com.example.cmput301w21t25.activities_main.SearchExperimentsActivity;
 import com.example.cmput301w21t25.activities_user.MyUserProfileActivity;
 import com.example.cmput301w21t25.custom.CustomListUser;
+import com.example.cmput301w21t25.custom.HideTrialDialogFragment;
+import com.example.cmput301w21t25.custom.ShowTrialDialogFragment;
 import com.example.cmput301w21t25.custom.UploadTrialDialogFragment;
 import com.example.cmput301w21t25.experiments.Experiment;
 import com.example.cmput301w21t25.user.User;
@@ -55,7 +57,12 @@ public class HideTrialActivity extends AppCompatActivity {
         userListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             @Override
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                new UploadTrialDialogFragment(position).show(getSupportFragmentManager(), "UPLOAD_TRIAL");
+                if (hiddenUsers.contains(allUsers.get(position))) {
+                    new ShowTrialDialogFragment(position).show(getSupportFragmentManager(), "SHOW_USER_TRIALS");
+                }
+                else {
+                    new HideTrialDialogFragment(position).show(getSupportFragmentManager(), "HIDE_USER_TRIALS");
+                }
             }
         });
     }

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/HideTrialActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/HideTrialActivity.java
@@ -26,7 +26,12 @@ import com.example.cmput301w21t25.user.User;
 
 import java.util.ArrayList;
 
-public class HideTrialActivity extends AppCompatActivity {
+/**
+ * @author Eden
+ * The hide trial activity displays a list of users who have added trials to your experiment. You
+ * can select users to hide their trials, then select them once again to show their trials
+ */
+public class HideTrialActivity extends AppCompatActivity implements HideTrialDialogFragment.OnFragmentInteractionListenerHide, ShowTrialDialogFragment.OnFragmentInteractionListenerShow {
 
     ListView userListView;
     ArrayAdapter<User> userArrayAdapter;
@@ -47,11 +52,21 @@ public class HideTrialActivity extends AppCompatActivity {
         Toolbar toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
+        //Test objects
+        //User user1 = new User("User1", "user1@example.com");
+        //User user2 = new User("User2", "user2@example.com");
+        //User user3 = new User("User3", "user3@example.com");
+
+        //allUsers.add(user1);
+        //allUsers.add(user2);
+        //allUsers.add(user3);
+        //hiddenUsers.add(user2);
+
         userID = getIntent().getStringExtra("USER_ID");
         exp = (Experiment) getIntent().getSerializableExtra("EXPERIMENT");
 
         userArrayAdapter = new CustomListUser(this, allUsers, hiddenUsers);
-        //Pass adapter to function that gets user list/hidden user list
+        //@Yalmaz pass adapter to function that gets user list/hidden user list
 
         userListView = findViewById(R.id.hide_trials_list);
         userListView.setAdapter(userArrayAdapter);
@@ -109,4 +124,19 @@ public class HideTrialActivity extends AppCompatActivity {
         }
     }
 
+    @Override
+    public void hideUser(Integer position) {
+        //@Yalmaz db call to add user to hidden list
+        //User temp = allUsers.get(position);
+        //hiddenUsers.add(temp);
+        //userArrayAdapter.notifyDataSetChanged();
+    }
+
+    @Override
+    public void showUser(Integer position) {
+        //@Yalmaz db call to remove user from hidden list
+        //User temp = allUsers.get(position);
+        //hiddenUsers.remove(temp);
+        //userArrayAdapter.notifyDataSetChanged();
+    }
 }

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/HideTrialActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/HideTrialActivity.java
@@ -2,6 +2,8 @@ package com.example.cmput301w21t25.activities_trials;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
@@ -65,6 +67,19 @@ public class HideTrialActivity extends AppCompatActivity {
                 }
             }
         });
+    }
+
+    /**
+     * This event is menu setup!
+     * @param menu this is the menu being integrated
+     * @return true to indicate there is a menu (return false to turn off)
+     */
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        super.onCreateOptionsMenu(menu);
+        MenuInflater menuInflater = getMenuInflater();
+        menuInflater.inflate(R.menu.toolbar_menu,menu);
+        return true;
     }
 
     /**

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/HideTrialActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_trials/HideTrialActivity.java
@@ -1,0 +1,90 @@
+package com.example.cmput301w21t25.activities_trials;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.MenuItem;
+import android.view.View;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+
+import com.example.cmput301w21t25.R;
+import com.example.cmput301w21t25.activities_main.CreatedExperimentsActivity;
+import com.example.cmput301w21t25.activities_main.SearchExperimentsActivity;
+import com.example.cmput301w21t25.activities_user.MyUserProfileActivity;
+import com.example.cmput301w21t25.custom.CustomListUser;
+import com.example.cmput301w21t25.custom.UploadTrialDialogFragment;
+import com.example.cmput301w21t25.experiments.Experiment;
+import com.example.cmput301w21t25.user.User;
+
+import java.util.ArrayList;
+
+public class HideTrialActivity extends AppCompatActivity {
+
+    ListView userListView;
+    ArrayAdapter<User> userArrayAdapter;
+
+    private String userID;
+    private Experiment exp;
+
+    private ArrayList<User> allUsers = new ArrayList<>();
+    private ArrayList<User> hiddenUsers = new ArrayList<>();
+
+    @Override
+    protected void onCreate(Bundle passedData) {
+        super.onCreate(passedData);
+        setContentView(R.layout.activity_hide_trials);
+
+        /*setup the custom toolbar!
+         */
+        Toolbar toolbar = findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
+
+        userID = getIntent().getStringExtra("USER_ID");
+        exp = (Experiment) getIntent().getSerializableExtra("EXPERIMENT");
+
+        userArrayAdapter = new CustomListUser(this, allUsers, hiddenUsers);
+        //Pass adapter to function that gets user list/hidden user list
+
+        userListView = findViewById(R.id.hide_trials_list);
+        userListView.setAdapter(userArrayAdapter);
+
+        userListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                new UploadTrialDialogFragment(position).show(getSupportFragmentManager(), "UPLOAD_TRIAL");
+            }
+        });
+    }
+
+    /**
+     * This event is for menu item setup
+     * @param item these are items that will be added to the menu
+     * @return @return true to indicate there is this item (return false to turn off)
+     */
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        // Handle item selection
+        switch (item.getItemId()) {
+            case R.id.home_button:
+                Intent home = new Intent(HideTrialActivity.this, CreatedExperimentsActivity.class);
+                home.putExtra("USER_ID", userID);
+                startActivity(home);
+                return true;
+            case R.id.settings_button:
+                Intent user_settings = new Intent(HideTrialActivity.this, MyUserProfileActivity.class);
+                user_settings.putExtra("USER_ID", userID);
+                //I think this will work but have to check
+                user_settings.putExtra("TRIAL_PARENT", exp);
+                user_settings.putExtra("prevScreen", "HideTrial");
+                startActivity(user_settings);
+                return true;
+            default:
+                return super.onOptionsItemSelected(item);
+        }
+    }
+
+}

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_user/MyUserProfileActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_user/MyUserProfileActivity.java
@@ -17,6 +17,7 @@ import com.example.cmput301w21t25.activities_main.CreatedExperimentsActivity;
 import com.example.cmput301w21t25.activities_main.SubbedExperimentsActivity;
 import com.example.cmput301w21t25.activities_main.SearchExperimentsActivity;
 import com.example.cmput301w21t25.activities_trials.AddTrialActivity;
+import com.example.cmput301w21t25.activities_trials.HideTrialActivity;
 import com.example.cmput301w21t25.experiments.Experiment;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
@@ -118,6 +119,9 @@ public class MyUserProfileActivity extends AppCompatActivity {
                 intent.putExtra("TRIAL_PARENT", exp);
                 Log.i("curtis", "going back to add trial page");
                 break;
+            case "HideTrial":
+                intent = new Intent(MyUserProfileActivity.this, HideTrialActivity.class);
+                intent.putExtra("EXPERIMENT", exp);
 
             default:
                 intent = new Intent(MyUserProfileActivity.this, CreatedExperimentsActivity.class);

--- a/project/app/src/main/java/com/example/cmput301w21t25/activities_user/MyUserProfileActivity.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/activities_user/MyUserProfileActivity.java
@@ -122,6 +122,7 @@ public class MyUserProfileActivity extends AppCompatActivity {
             case "HideTrial":
                 intent = new Intent(MyUserProfileActivity.this, HideTrialActivity.class);
                 intent.putExtra("EXPERIMENT", exp);
+                break;
 
             default:
                 intent = new Intent(MyUserProfileActivity.this, CreatedExperimentsActivity.class);

--- a/project/app/src/main/java/com/example/cmput301w21t25/custom/CustomListComment.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/custom/CustomListComment.java
@@ -39,16 +39,14 @@ public class CustomListComment extends ArrayAdapter<Comment> {
     private Context context;
     private Experiment forumExperiment;
     private Comment comment;
-    private String userID;
     private Date date;
     private String dateString;
 
-    public CustomListComment(Context context, ArrayList<Comment> comments, Experiment forumExperiment, String userID) {
+    public CustomListComment(Context context, ArrayList<Comment> comments, Experiment forumExperiment) {
         super(context,0,comments);
         this.comments = comments;
         this.context = context;
         this.forumExperiment = forumExperiment;
-        this.userID = userID;
     }
 
     public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {

--- a/project/app/src/main/java/com/example/cmput301w21t25/custom/CustomListUser.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/custom/CustomListUser.java
@@ -1,0 +1,73 @@
+package com.example.cmput301w21t25.custom;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
+import com.example.cmput301w21t25.R;
+import com.example.cmput301w21t25.experiments.Experiment;
+import com.example.cmput301w21t25.forum.Comment;
+import com.example.cmput301w21t25.user.User;
+
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+
+/**
+ * @author Eden
+ * A custom array adapter used to display comments in list views
+ */
+public class CustomListUser extends ArrayAdapter<User> {
+    private ArrayList<User> allUsers;
+    private ArrayList<User> hiddenUsers;
+    private Context context;
+    private User user;
+
+    public CustomListUser(Context context, ArrayList<User> allUsers, ArrayList<User> hiddenUsers) {
+        super(context,0,allUsers);
+        this.allUsers = allUsers;
+        this.context = context;
+        this.hiddenUsers = hiddenUsers;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.LOLLIPOP)
+    public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+        View view = convertView;
+        //The content view is not displayed if the adapter is empty
+        if (view == null) {
+            view = LayoutInflater.from(context).inflate(R.layout.user_content, parent, false);
+        }
+
+        user = allUsers.get(position);
+
+        TextView userName = view.findViewById(R.id.userName);
+        TextView userEmail = view.findViewById(R.id.userContactInfo);
+
+        LinearLayout background = view.findViewById(R.id.userListBackground);
+        Drawable contentBackground = background.getBackground();
+
+        //Grey out the background if the user is hidden
+        if (hiddenUsers.contains(user)) {
+            contentBackground.setTint(context.getResources().getColor(R.color.custom_Grey));
+        }
+        if (!hiddenUsers.contains(user)) {
+            contentBackground.setTint(context.getResources().getColor(R.color.design_default_color_background));
+        }
+
+        userName.setText(user.getName());
+        userEmail.setText(user.getEmail());
+
+        return view;
+    }
+}

--- a/project/app/src/main/java/com/example/cmput301w21t25/custom/CustomListUser.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/custom/CustomListUser.java
@@ -26,7 +26,7 @@ import java.util.Date;
 
 /**
  * @author Eden
- * A custom array adapter used to display comments in list views
+ * A custom array adapter used to display users in list views
  */
 public class CustomListUser extends ArrayAdapter<User> {
     private ArrayList<User> allUsers;

--- a/project/app/src/main/java/com/example/cmput301w21t25/custom/HideTrialDialogFragment.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/custom/HideTrialDialogFragment.java
@@ -1,0 +1,62 @@
+package com.example.cmput301w21t25.custom;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+
+import com.example.cmput301w21t25.R;
+
+public class HideTrialDialogFragment extends DialogFragment {
+
+    public interface OnFragmentInteractionListener {
+        void publishTrial(Integer position);
+    }
+
+    private OnFragmentInteractionListener listener;
+    private Integer position;
+
+    public HideTrialDialogFragment(Integer position) {
+        this.position = position;
+    }
+
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        if (context instanceof OnFragmentInteractionListener){
+            listener = (OnFragmentInteractionListener) context;
+        } else {
+            throw new RuntimeException(context.toString()
+                    + " must implement OnFragmentInteractionListener");
+        }
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
+        View view = LayoutInflater.from(getActivity()).inflate(R.layout.upload_trial_fragment, null);
+
+        AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
+        return builder
+                .setView(view)
+                .setTitle("              Upload Trial?")
+                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialog, int i) {
+                    }
+                })
+                .setPositiveButton("Upload", new DialogInterface.OnClickListener() {
+                    @Override
+                    public void onClick(DialogInterface dialogInterface, int i) {
+                        listener.publishTrial(position);
+                    }}).create();
+    }
+}

--- a/project/app/src/main/java/com/example/cmput301w21t25/custom/HideTrialDialogFragment.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/custom/HideTrialDialogFragment.java
@@ -14,6 +14,12 @@ import androidx.fragment.app.DialogFragment;
 
 import com.example.cmput301w21t25.R;
 
+/**
+ * @author Eden
+ * A dialog fragment that appears when an experiment owner clicks on an item in the HideTrialActivity
+ * list view. It prompts the owner as to whether they want to hide the selected user's trials that
+ * have been uploaded to the owner's experiment.
+ */
 public class HideTrialDialogFragment extends DialogFragment {
 
     public interface OnFragmentInteractionListenerHide {

--- a/project/app/src/main/java/com/example/cmput301w21t25/custom/ShowTrialDialogFragment.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/custom/ShowTrialDialogFragment.java
@@ -14,16 +14,16 @@ import androidx.fragment.app.DialogFragment;
 
 import com.example.cmput301w21t25.R;
 
-public class HideTrialDialogFragment extends DialogFragment {
+public class ShowTrialDialogFragment extends DialogFragment {
 
-    public interface OnFragmentInteractionListenerHide {
-        void hideUser(Integer position);
+    public interface OnFragmentInteractionListenerShow {
+        void showUser(Integer position);
     }
 
-    private OnFragmentInteractionListenerHide listener;
+    private OnFragmentInteractionListenerShow listener;
     private Integer position;
 
-    public HideTrialDialogFragment(Integer position) {
+    public ShowTrialDialogFragment(Integer position) {
         this.position = position;
     }
 
@@ -31,8 +31,8 @@ public class HideTrialDialogFragment extends DialogFragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        if (context instanceof OnFragmentInteractionListenerHide){
-            listener = (OnFragmentInteractionListenerHide) context;
+        if (context instanceof OnFragmentInteractionListenerShow){
+            listener = (OnFragmentInteractionListenerShow) context;
         } else {
             throw new RuntimeException(context.toString()
                     + " must implement OnFragmentInteractionListener");
@@ -42,7 +42,7 @@ public class HideTrialDialogFragment extends DialogFragment {
     @NonNull
     @Override
     public Dialog onCreateDialog(@Nullable Bundle savedInstanceState) {
-        View view = LayoutInflater.from(getActivity()).inflate(R.layout.hide_user_fragment, null);
+        View view = LayoutInflater.from(getActivity()).inflate(R.layout.show_user_fragment, null);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getContext());
         return builder
@@ -52,10 +52,10 @@ public class HideTrialDialogFragment extends DialogFragment {
                     public void onClick(DialogInterface dialog, int i) {
                     }
                 })
-                .setPositiveButton("Hide", new DialogInterface.OnClickListener() {
+                .setPositiveButton("Show", new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
-                        listener.hideUser(position);
+                        listener.showUser(position);
                     }}).create();
     }
 }

--- a/project/app/src/main/java/com/example/cmput301w21t25/custom/ShowTrialDialogFragment.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/custom/ShowTrialDialogFragment.java
@@ -14,6 +14,12 @@ import androidx.fragment.app.DialogFragment;
 
 import com.example.cmput301w21t25.R;
 
+/**
+ * @author Eden
+ * A dialog fragment that appears when an experiment owner clicks on an item in the HideTrialActivity
+ * list view. It prompts the owner as to whether they want to show the selected user's trials that
+ * have been uploaded to the owner's experiment.
+ */
 public class ShowTrialDialogFragment extends DialogFragment {
 
     public interface OnFragmentInteractionListenerShow {

--- a/project/app/src/main/java/com/example/cmput301w21t25/custom/UploadTrialDialogFragment.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/custom/UploadTrialDialogFragment.java
@@ -16,11 +16,11 @@ import com.example.cmput301w21t25.R;
 
 public class UploadTrialDialogFragment extends DialogFragment {
 
-    public interface OnFragmentInteractionListener {
+    public interface OnFragmentInteractionListenerUpload {
         void publishTrial(Integer position);
     }
 
-    private OnFragmentInteractionListener listener;
+    private OnFragmentInteractionListenerUpload listener;
     private Integer position;
 
     public UploadTrialDialogFragment(Integer position) {
@@ -31,8 +31,8 @@ public class UploadTrialDialogFragment extends DialogFragment {
     @Override
     public void onAttach(Context context) {
         super.onAttach(context);
-        if (context instanceof OnFragmentInteractionListener){
-            listener = (OnFragmentInteractionListener) context;
+        if (context instanceof OnFragmentInteractionListenerUpload){
+            listener = (OnFragmentInteractionListenerUpload) context;
         } else {
             throw new RuntimeException(context.toString()
                     + " must implement OnFragmentInteractionListener");

--- a/project/app/src/main/java/com/example/cmput301w21t25/custom/UploadTrialDialogFragment.java
+++ b/project/app/src/main/java/com/example/cmput301w21t25/custom/UploadTrialDialogFragment.java
@@ -14,6 +14,12 @@ import androidx.fragment.app.DialogFragment;
 
 import com.example.cmput301w21t25.R;
 
+/**
+ * @author Eden
+ * A dialog fragment that prompts the user when they click on a trial they've created, asking
+ * whether or not they want to upload the trial, as this action can't be undone.
+ * Is called in AddTrialActivity
+ */
 public class UploadTrialDialogFragment extends DialogFragment {
 
     public interface OnFragmentInteractionListenerUpload {

--- a/project/app/src/main/res/layout/activity_hide_trials.xml
+++ b/project/app/src/main/res/layout/activity_hide_trials.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--https://stackoverflow.com/questions/16556106/how-to-add-space-between-items-in-android-listview/16556203-->
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#f6f5f5"
+    android:orientation="vertical">
+
+    <include
+        layout = "@layout/custom_toolbar"/>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ListView
+            android:id="@+id/hide_trials_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="5dp"
+            android:layout_marginTop="13dp"
+            android:layout_marginRight="5dp"
+            android:divider="@android:color/transparent"
+            android:dividerHeight="8dp" />
+
+    </FrameLayout>
+
+
+</LinearLayout>

--- a/project/app/src/main/res/layout/activity_view_created_experiment.xml
+++ b/project/app/src/main/res/layout/activity_view_created_experiment.xml
@@ -134,7 +134,7 @@
             android:layout_marginStart="35dp"
             android:layout_marginLeft="35dp"
             android:layout_weight="1"
-            android:text="Button" />
+            android:text="Hide Trials" />
 
     </LinearLayout>
 

--- a/project/app/src/main/res/layout/activity_view_created_experiment.xml
+++ b/project/app/src/main/res/layout/activity_view_created_experiment.xml
@@ -111,17 +111,35 @@
 
     </LinearLayout>
 
-    <Button
-        android:id="@+id/view_data_button"
-        android:layout_width="150dp"
-        android:layout_height="60dp"
-        android:layout_above="@id/button_linear_layout"
-        android:layout_centerHorizontal="true"
-        android:layout_marginTop="36dp"
-        android:text="view data" />
-
     <LinearLayout
         android:id="@+id/button_linear_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_above="@id/button_linear_layout2"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="12dp"
+        android:layout_marginBottom="71dp"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/view_data_button"
+            android:layout_width="150dp"
+            android:layout_height="60dp"
+            android:text="view data" />
+
+        <Button
+            android:id="@+id/hideTrialsButton"
+            android:layout_width="150dp"
+            android:layout_height="60dp"
+            android:layout_marginStart="35dp"
+            android:layout_marginLeft="35dp"
+            android:layout_weight="1"
+            android:text="Button" />
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/button_linear_layout3"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_above="@id/button_linear_layout2"

--- a/project/app/src/main/res/layout/hide_user_fragment.xml
+++ b/project/app/src/main/res/layout/hide_user_fragment.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="100dp" >
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Hide User's Trials?"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/project/app/src/main/res/layout/show_user_fragment.xml
+++ b/project/app/src/main/res/layout/show_user_fragment.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="100dp" >
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Show User's Trials?"
+        android:textSize="20sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/project/app/src/main/res/layout/user_content.xml
+++ b/project/app/src/main/res/layout/user_content.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@drawable/list_info_background"
-    android:backgroundTint="@color/cus"
+    android:backgroundTint="@color/design_default_color_background"
     android:orientation="horizontal"
     android:padding="10dp">
 

--- a/project/app/src/main/res/layout/user_content.xml
+++ b/project/app/src/main/res/layout/user_content.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/userListBackground"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/list_info_background"
+    android:backgroundTint="@color/cus"
+    android:orientation="horizontal"
+    android:padding="10dp">
+
+
+    <ImageView
+        android:id="@+id/defaultUserImage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        app:srcCompat="@drawable/user_settings"
+        android:padding="10dp"/>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/userName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="This Be Doth Experiment Name"
+            android:textColor="@color/custom_Yellow_dark"
+            android:textSize="18sp" />
+
+        <TextView
+            android:id="@+id/userContactInfo"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingLeft="1sp"
+            android:text="UserJohnnyBoi"
+            android:textColor="@color/custom_Blue_light"
+            android:textSize="14sp" />
+
+    </LinearLayout>
+
+</LinearLayout>


### PR DESCRIPTION
So the GUI/activity business is working well for hiding trials (I left commented out test objects/code in the override methods if anyone wants to take a look). It'll just be a matter of Yalmaz's database calls now. Let me know if the grey is a bit too dark-- I was just using our custom but maybe we should go lighter? 

What's new: 
-Custom array adapter for User objects
-Dialog fragments/layouts for hiding/showing trials
-Layout for the hide trial activity
-The hide trial activity itself
-Added in the toolbar functionality for this activity (Samadhi let me know if I should have done blue!), so added another case to Curtis' user activity
-Added hideTrial button to view created experiment layout, as well as the onClickListener to the activity